### PR TITLE
Address failing unit test

### DIFF
--- a/aviatrix/data_source_aviatrix_account_test.go
+++ b/aviatrix/data_source_aviatrix_account_test.go
@@ -19,10 +19,11 @@ func TestAccDataSourceAviatrixAccount_basic(t *testing.T) {
 		t.Skip("Skipping Data Source Account test as SKIP_DATA_ACCOUNT is set")
 	}
 
-	preAccountCheck(t, ". Set SKIP_DATA_ACCOUNT to yes to skip Data Source Account tests")
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, ". Set SKIP_DATA_ACCOUNT to yes to skip Data Source Account tests")
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aviatrix/data_source_aviatrix_caller_identity_test.go
+++ b/aviatrix/data_source_aviatrix_caller_identity_test.go
@@ -22,10 +22,11 @@ func TestAccDataSourceAviatrixCallerIdentity_basic(t *testing.T) {
 		t.Skip("Skipping Data Source Caller Identity test as SKIP_DATA_CALLER_IDENTITY is set")
 	}
 
-	preAccountCheck(t, ". Set SKIP_DATA_CALLER_IDENTITY to yes to skip Data Source Caller Identity tests")
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, ". Set SKIP_DATA_CALLER_IDENTITY to yes to skip Data Source Caller Identity tests")
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aviatrix/data_source_aviatrix_gateway_test.go
+++ b/aviatrix/data_source_aviatrix_gateway_test.go
@@ -19,10 +19,11 @@ func TestAccDataSourceAviatrixGateway_basic(t *testing.T) {
 		t.Skip("Skipping Data Source Gateway test as SKIP_DATA_GATEWAY is set")
 	}
 
-	preGatewayCheck(t, ". Set SKIP_DATA_GATEWAY to yes to skip Data Source Gateway tests")
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preGatewayCheck(t, ". Set SKIP_DATA_GATEWAY to yes to skip Data Source Gateway tests")
+		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/aviatrix/resource_aviatrix_account_test.go
+++ b/aviatrix/resource_aviatrix_account_test.go
@@ -66,14 +66,15 @@ func TestAccAviatrixAccount_basic(t *testing.T) {
 
 	}
 
-	preAccountCheck(t, ". Set SKIP_ACCOUNT to yes to skip account tests")
-
 	if skipAWS == "yes" {
 		t.Log("Skipping AWS Access Account test as SKIP_AWS_ACCOUNT is set")
 	} else {
 		resourceName := "aviatrix_account.aws"
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preAccountCheck(t, ". Set SKIP_ACCOUNT to yes to skip account tests")
+			},
 			Providers:    testAccProviders,
 			CheckDestroy: testAccCheckAccountDestroy,
 			Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_arm_peer_test.go
+++ b/aviatrix/resource_aviatrix_arm_peer_test.go
@@ -34,7 +34,7 @@ func preARMPeerCheck(t *testing.T, msgCommon string) (string, string, string, st
 
 func TestAccAviatrixARMPeer_basic(t *testing.T) {
 	var armPeer goaviatrix.ARMPeer
-
+	var vNet1, vNet2, region1, region2 string
 	rInt := acctest.RandInt()
 	resourceName := "aviatrix_arm_peer.test_arm_peer"
 
@@ -44,12 +44,12 @@ func TestAccAviatrixARMPeer_basic(t *testing.T) {
 	}
 	msgCommon := ". Set SKIP_ARM_PEER to yes to skip AWS peer tests"
 
-	preAccountCheck(t, msgCommon)
-
-	vNet1, vNet2, region1, region2 := preARMPeerCheck(t, msgCommon)
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, msgCommon)
+			vNet1, vNet2, region1, region2 = preARMPeerCheck(t, msgCommon)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckARMPeerDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_aws_peer_test.go
+++ b/aviatrix/resource_aviatrix_aws_peer_test.go
@@ -34,6 +34,7 @@ func preAWSPeerCheck(t *testing.T, msgCommon string) (string, string, string, st
 
 func TestAccAviatrixAWSPeer_basic(t *testing.T) {
 	var awsPeer goaviatrix.AWSPeer
+	var vpcID1, vpcID2, region1, region2 string
 
 	rInt := acctest.RandInt()
 	resourceName := "aviatrix_aws_peer.test_aws_peer"
@@ -44,12 +45,12 @@ func TestAccAviatrixAWSPeer_basic(t *testing.T) {
 	}
 	msgCommon := ". Set SKIP_AWS_PEER to yes to skip AWS peer tests"
 
-	preAccountCheck(t, msgCommon)
-
-	vpcID1, vpcID2, region1, region2 := preAWSPeerCheck(t, msgCommon)
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, msgCommon)
+			vpcID1, vpcID2, region1, region2 = preAWSPeerCheck(t, msgCommon)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSPeerDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_aws_tgw_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_test.go
@@ -24,13 +24,14 @@ func TestAccAviatrixAWSTgw_basic(t *testing.T) {
 	}
 	msg := ". Set SKIP_AWS_TGW to yes to skip AWS TGW  tests"
 
-	preAccountCheck(t, msg)
-
 	awsSideAsNumber := "64512"
 	sDm := "zSecurityDomain"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, msg)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSTgwDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_vpc_attachment_test.go
@@ -23,13 +23,14 @@ func TestAccAviatrixAwsTgwVpcAttachment_basic(t *testing.T) {
 	}
 	msg := ". Set SKIP_AWS_TGW_VPC_ATTACHMENT to yes to skip AWS TGW VPC ATTACH tests"
 
-	preAccountCheck(t, msg)
-
 	awsSideAsNumber := "64512"
 	sDm := "mySdn"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, msg)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsTgwVpcAttachmentDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_aws_tgw_vpn_conn_test.go
+++ b/aviatrix/resource_aviatrix_aws_tgw_vpn_conn_test.go
@@ -24,12 +24,13 @@ func TestAccAviatrixAwsTgwVpnConn_basic(t *testing.T) {
 
 	msg := ". Set SKIP_AWS_TGW_VPN_CONN to yes to skip AWS TGW VPN CONN tests"
 
-	preAccountCheck(t, msg)
-
 	awsSideAsNumber := "12"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, msg)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsTgwVpnConnDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_controller_config_test.go
+++ b/aviatrix/resource_aviatrix_controller_config_test.go
@@ -21,11 +21,13 @@ func TestAccAviatrixControllerConfig_basic(t *testing.T) {
 		t.Skip("Skipping Controller Config test as SKIP_CONTROLLER_CONFIG is set")
 	}
 	msgCommon := ". Set SKIP_CONTROLLER_CONFIG to yes to skip Controller Config tests"
-	preAccountCheck(t, msgCommon)
 	resourceName := "aviatrix_controller_config.test_controller_config"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, msgCommon)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckControllerConfigDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_firewall_test.go
+++ b/aviatrix/resource_aviatrix_firewall_test.go
@@ -23,10 +23,11 @@ func TestAccAviatrixFirewall_basic(t *testing.T) {
 	}
 	msg := ". Set SKIP_FIREWALL to yes to skip firewall tests"
 
-	preGatewayCheck(t, msg)
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preGatewayCheck(t, msg)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckFirewallDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_fqdn_test.go
+++ b/aviatrix/resource_aviatrix_fqdn_test.go
@@ -21,12 +21,13 @@ func TestAccAviatrixFQDN_basic(t *testing.T) {
 		t.Skip("Skipping FQDN test as SKIP_FQDN is set")
 	}
 
-	preGatewayCheck(t, ". Set SKIP_FQDN to yes to skip FQDN tests")
-
 	resourceName := "aviatrix_fqdn.foo"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preGatewayCheck(t, ". Set SKIP_FQDN to yes to skip FQDN tests")
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckFQDNDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_gateway_test.go
+++ b/aviatrix/resource_aviatrix_gateway_test.go
@@ -88,9 +88,6 @@ func TestAccAviatrixGateway_basic(t *testing.T) {
 			"even though SKIP_GATEWAY isn't set")
 	}
 
-	//Checking resources have needed environment variables set
-	preAccountCheck(t, msgCommon)
-
 	//Setting default values for AWS_GW_SIZE and GCP_GW_SIZE
 	awsGwSize := os.Getenv("AWS_GW_SIZE")
 	gcpGwSize := os.Getenv("GCP_GW_SIZE")
@@ -104,13 +101,17 @@ func TestAccAviatrixGateway_basic(t *testing.T) {
 	if skipAWS == "yes" {
 		t.Log("Skipping AWS Gateway test as SKIP_AWS_GATEWAY is set")
 	} else {
+		var awsVpcId, awsRegion, awsVpcNet string
 		resourceNameAws := "aviatrix_gateway.test_gw_aws"
 		msgCommonAws := ". Set SKIP_AWS_GATEWAY to yes to skip AWS Gateway tests"
 
-		awsVpcId, awsRegion, awsVpcNet := preGatewayCheck(t, msgCommonAws)
-
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
+			PreCheck: func() {
+				testAccPreCheck(t)
+				//Checking resources have needed environment variables set
+				preAccountCheck(t, msgCommon)
+				awsVpcId, awsRegion, awsVpcNet = preGatewayCheck(t, msgCommonAws)
+			},
 			Providers:    testAccProviders,
 			CheckDestroy: testAccCheckGatewayDestroy,
 			Steps: []resource.TestStep{
@@ -137,13 +138,17 @@ func TestAccAviatrixGateway_basic(t *testing.T) {
 	if skipGCP == "yes" {
 		t.Log("Skipping GCP Gateway test as SKIP_GCP_GATEWAY is set")
 	} else {
+		var gcpVpcId, gcpZone, gcpSubnet string
 		resourceNameGcp := "aviatrix_gateway.test_gw_gcp"
 		msgCommonGcp := ". Set SKIP_GCP_GATEWAY to yes to skip GCP Gateway tests"
 
-		gcpVpcId, gcpZone, gcpSubnet := preGatewayCheckGCP(t, msgCommonGcp)
-
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
+			PreCheck: func() {
+				testAccPreCheck(t)
+				//Checking resources have needed environment variables set
+				preAccountCheck(t, msgCommon)
+				gcpVpcId, gcpZone, gcpSubnet = preGatewayCheckGCP(t, msgCommonGcp)
+			},
 			Providers:    testAccProviders,
 			CheckDestroy: testAccCheckGatewayDestroy,
 			Steps: []resource.TestStep{
@@ -170,13 +175,17 @@ func TestAccAviatrixGateway_basic(t *testing.T) {
 	if skipARM == "yes" {
 		t.Log("Skipping ARM Gateway test as SKIP_ARM_GATEWAY is set")
 	} else {
+		var armVnetId, armRegion, armSubnet, armGwSize string
 		resourceNameArm := "aviatrix_gateway.test_gw_arm"
 		msgCommonArm := ". Set SKIP_ARM_GATEWAY to yes to skip ARM Gateway tests"
 
-		armVnetId, armRegion, armSubnet, armGwSize := preGatewayCheckARM(t, msgCommonArm)
-
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
+			PreCheck: func() {
+				testAccPreCheck(t)
+				//Checking resources have needed environment variables set
+				preAccountCheck(t, msgCommon)
+				armVnetId, armRegion, armSubnet, armGwSize = preGatewayCheckARM(t, msgCommonArm)
+			},
 			Providers:    testAccProviders,
 			CheckDestroy: testAccCheckGatewayDestroy,
 			Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_saml_endpoint_test.go
+++ b/aviatrix/resource_aviatrix_saml_endpoint_test.go
@@ -33,7 +33,7 @@ func preAvxSamlEndpointCheck(t *testing.T, msgCommon string) (string, string) {
 
 func TestAccAviatrixSamlEndpoint_basic(t *testing.T) {
 	var samlEndpoint goaviatrix.SamlEndpoint
-
+	var idpMetadata, idpMetadataType string
 	rName := acctest.RandString(5)
 	resourceName := "aviatrix_saml_endpoint.foo"
 
@@ -43,10 +43,11 @@ func TestAccAviatrixSamlEndpoint_basic(t *testing.T) {
 	}
 	msgCommon := ". Set SKIP_SAML_ENDPOINT to yes to skip Aviatrix SAML Endpoint tests"
 
-	idpMetadata, idpMetadataType := preAvxSamlEndpointCheck(t, msgCommon)
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			idpMetadata, idpMetadataType = preAvxSamlEndpointCheck(t, msgCommon)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSamlEndpointDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_site2cloud_test.go
+++ b/aviatrix/resource_aviatrix_site2cloud_test.go
@@ -22,10 +22,12 @@ func TestAccAviatrixS2C_basic(t *testing.T) {
 		t.Skip("Skipping Site2Cloud test as SKIP_S2C is set")
 	}
 
-	preGatewayCheck(t, ". Set SKIP_S2C to yes to skip Site2Cloud tests")
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preGatewayCheck(t, ". Set SKIP_S2C to yes to skip Site2Cloud tests")
+
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckS2CDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_spoke_gateway_test.go
+++ b/aviatrix/resource_aviatrix_spoke_gateway_test.go
@@ -35,9 +35,6 @@ func TestAccAviatrixSpokeGateway_basic(t *testing.T) {
 			"and SKIP_SPOKE_GATEWAY_ARM are all set, even though SKIP_SPOKE_GATEWAY isn't set")
 	}
 
-	preGatewayCheck(t, msgCommon)
-	preSpokeGatewayCheck(t, msgCommon)
-
 	//Setting default values for AWS_GW_SIZE and GCP_GW_SIZE
 	awsGwSize := os.Getenv("AWS_GW_SIZE")
 	gcpGwSize := os.Getenv("GCP_GW_SIZE")
@@ -52,7 +49,11 @@ func TestAccAviatrixSpokeGateway_basic(t *testing.T) {
 		t.Log("Skipping AWS Spoke Gateway test as SKIP_SPOKE_GATEWAY_AWS is set")
 	} else {
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preGatewayCheck(t, msgCommon)
+				preSpokeGatewayCheck(t, msgCommon)
+			},
 			Providers:    testAccProviders,
 			CheckDestroy: testAccCheckSpokeGatewayDestroy,
 			Steps: []resource.TestStep{
@@ -82,7 +83,11 @@ func TestAccAviatrixSpokeGateway_basic(t *testing.T) {
 		t.Log("Skipping GCP Spoke Gateway test as SKIP_SPOKE_GATEWAY_GCP is set")
 	} else {
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preGatewayCheck(t, msgCommon)
+				preSpokeGatewayCheck(t, msgCommon)
+			},
 			Providers:    testAccProviders,
 			CheckDestroy: testAccCheckSpokeGatewayDestroy,
 			Steps: []resource.TestStep{
@@ -113,7 +118,11 @@ func TestAccAviatrixSpokeGateway_basic(t *testing.T) {
 	} else {
 		importStateVerifyIgnore = append(importStateVerifyIgnore, "vpc_id")
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preGatewayCheck(t, msgCommon)
+				preSpokeGatewayCheck(t, msgCommon)
+			},
 			Providers:    testAccProviders,
 			CheckDestroy: testAccCheckSpokeGatewayDestroy,
 			Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_spoke_vpc_test.go
+++ b/aviatrix/resource_aviatrix_spoke_vpc_test.go
@@ -45,9 +45,6 @@ func TestAccAviatrixSpokeGw_basic(t *testing.T) {
 			"even though SKIP_SPOKE isn't set")
 	}
 
-	preGatewayCheck(t, msgCommon)
-	preSpokeGatewayCheck(t, msgCommon)
-
 	//Setting default values for AWS_GW_SIZE and GCP_GW_SIZE
 	awsGwSize := os.Getenv("AWS_GW_SIZE")
 	gcpGwSize := os.Getenv("GCP_GW_SIZE")
@@ -62,7 +59,11 @@ func TestAccAviatrixSpokeGw_basic(t *testing.T) {
 		t.Log("Skipping AWS Spoke Gateway test as SKIP_SPOKE_AWS is set")
 	} else {
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preGatewayCheck(t, msgCommon)
+				preSpokeGatewayCheck(t, msgCommon)
+			},
 			Providers:    testAccProviders,
 			CheckDestroy: testAccCheckSpokeGwDestroy,
 			Steps: []resource.TestStep{
@@ -92,7 +93,11 @@ func TestAccAviatrixSpokeGw_basic(t *testing.T) {
 		t.Log("Skipping GCP Spoke Gateway test as SKIP_SPOKE_GCP is set")
 	} else {
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preGatewayCheck(t, msgCommon)
+				preSpokeGatewayCheck(t, msgCommon)
+			},
 			Providers:    testAccProviders,
 			CheckDestroy: testAccCheckSpokeGwDestroy,
 			Steps: []resource.TestStep{
@@ -123,7 +128,11 @@ func TestAccAviatrixSpokeGw_basic(t *testing.T) {
 	} else {
 		importStateVerifyIgnore = append(importStateVerifyIgnore, "vpc_id")
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preGatewayCheck(t, msgCommon)
+				preSpokeGatewayCheck(t, msgCommon)
+			},
 			Providers:    testAccProviders,
 			CheckDestroy: testAccCheckSpokeGwDestroy,
 			Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_trans_peer_test.go
+++ b/aviatrix/resource_aviatrix_trans_peer_test.go
@@ -21,6 +21,7 @@ func preTransPeerCheck(t *testing.T, msgCommon string) (string, string, string, 
 
 func TestAccAviatrixTransPeer_basic(t *testing.T) {
 	var transpeer goaviatrix.TransPeer
+	var sourceVPC, region1, subnet1, nextHopVPC, region2, subnet2, reachableCIDR string
 
 	rName := acctest.RandString(5)
 	resourceName := "aviatrix_trans_peer.test_trans_peer"
@@ -31,12 +32,12 @@ func TestAccAviatrixTransPeer_basic(t *testing.T) {
 	}
 	msgCommon := ". Set SKIP_TRANS_PEER to yes to skip transitive peer tests"
 
-	preAccountCheck(t, msgCommon)
-
-	sourceVPC, region1, subnet1, nextHopVPC, region2, subnet2, reachableCIDR := preTransPeerCheck(t, msgCommon)
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, msgCommon)
+			sourceVPC, region1, subnet1, nextHopVPC, region2, subnet2, reachableCIDR = preTransPeerCheck(t, msgCommon)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccTransPeerDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_transit_gateway_peering_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_peering_test.go
@@ -20,6 +20,7 @@ func preAvxTransitGatewayPeeringCheck(t *testing.T, msgCommon string) (string, s
 
 func TestAccAviatrixTransitGatewayPeering_basic(t *testing.T) {
 	rName := acctest.RandString(5)
+	var vpcID1, region1, subnet1, haSubnet1, vpcID2, region2, subnet2, haSubnet2 string
 
 	resourceName := "aviatrix_transit_gateway_peering.foo"
 
@@ -29,10 +30,11 @@ func TestAccAviatrixTransitGatewayPeering_basic(t *testing.T) {
 	}
 	msgCommon := ". Set SKIP_TRANSIT_GATEWAY_PEERING to yes to skip Aviatrix transit gateway peering tests"
 
-	vpcID1, region1, subnet1, haSubnet1, vpcID2, region2, subnet2, haSubnet2 := preAvxTransitGatewayPeeringCheck(t, msgCommon)
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			vpcID1, region1, subnet1, haSubnet1, vpcID2, region2, subnet2, haSubnet2 = preAvxTransitGatewayPeeringCheck(t, msgCommon)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTransitGatewayPeeringDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_transit_gateway_test.go
+++ b/aviatrix/resource_aviatrix_transit_gateway_test.go
@@ -31,10 +31,11 @@ func TestAccAviatrixTransitGateway_basic(t *testing.T) {
 		resourceNameAws := "aviatrix_transit_gateway.test_transit_gateway_aws"
 		msgCommonAws := ". Set SKIP_TRANSIT_GATEWAY_AWS to yes to skip Transit Gateway tests in aws"
 
-		preGatewayCheck(t, msgCommonAws)
-
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preGatewayCheck(t, msgCommonAws)
+			},
 			Providers:    testAccProviders,
 			CheckDestroy: testAccCheckTransitGatewayDestroy,
 			Steps: []resource.TestStep{
@@ -65,10 +66,12 @@ func TestAccAviatrixTransitGateway_basic(t *testing.T) {
 		resourceNameArm := "aviatrix_transit_gateway.test_transit_gateway_arm"
 
 		msgCommonArm := ". Set SKIP_TRANSIT_GATEWAY_ARM to yes to skip Transit Gateway tests in ARM"
-		preGatewayCheckArm(t, msgCommonArm)
 
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preGatewayCheckArm(t, msgCommonArm)
+			},
 			Providers:    testAccProviders,
 			CheckDestroy: testAccCheckTransitGatewayDestroy,
 			Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_transit_vpc_test.go
+++ b/aviatrix/resource_aviatrix_transit_vpc_test.go
@@ -51,10 +51,11 @@ func TestAccAviatrixTransitGw_basic(t *testing.T) {
 		resourceNameAws := "aviatrix_transit_vpc.test_transit_vpc_aws"
 		msgCommonAws := ". Set SKIP_TRANSIT_AWS to yes to skip Transit Gateway tests in aws"
 
-		preGatewayCheck(t, msgCommonAws)
-
 		resource.Test(t, resource.TestCase{
-			PreCheck:     func() { testAccPreCheck(t) },
+			PreCheck: func() {
+				testAccPreCheck(t)
+				preGatewayCheck(t, msgCommonAws)
+			},
 			Providers:    testAccProviders,
 			CheckDestroy: testAccCheckTransitGwDestroy,
 			Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_tunnel_test.go
+++ b/aviatrix/resource_aviatrix_tunnel_test.go
@@ -39,7 +39,7 @@ func preAvxTunnelCheck(t *testing.T, msgCommon string) (string, string, string, 
 
 func TestAccAviatrixTunnel_basic(t *testing.T) {
 	var tun goaviatrix.Tunnel
-
+	var vpcID1, region1, subnet1, vpcID2, region2, subnet2 string
 	rName := acctest.RandString(5)
 	resourceName := "aviatrix_tunnel.foo"
 
@@ -49,10 +49,11 @@ func TestAccAviatrixTunnel_basic(t *testing.T) {
 	}
 	msgCommon := ". Set SKIP_TUNNEL to yes to skip Aviatrix peering tunnel tests"
 
-	vpcID1, region1, subnet1, vpcID2, region2, subnet2 := preAvxTunnelCheck(t, msgCommon)
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			vpcID1, region1, subnet1, vpcID2, region2, subnet2 = preAvxTunnelCheck(t, msgCommon)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckTunnelDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_vgw_conn_test.go
+++ b/aviatrix/resource_aviatrix_vgw_conn_test.go
@@ -26,6 +26,7 @@ func preVGWConnCheck(t *testing.T, msgCommon string) (string, string) {
 
 func TestAccAviatrixVGWConn_basic(t *testing.T) {
 	var vgwConn goaviatrix.VGWConn
+	var vpcID, bgpVGWId string
 
 	rName := acctest.RandString(5)
 
@@ -37,10 +38,11 @@ func TestAccAviatrixVGWConn_basic(t *testing.T) {
 	}
 	msgCommon := ". Set SKIP_VGW_CONN to yes to skip VGW connection tests"
 
-	vpcID, bgpVGWId := preVGWConnCheck(t, msgCommon)
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			vpcID, bgpVGWId = preVGWConnCheck(t, msgCommon)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVGWConnDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_vpc_test.go
+++ b/aviatrix/resource_aviatrix_vpc_test.go
@@ -23,10 +23,12 @@ func TestAccAviatrixVpc_basic(t *testing.T) {
 	}
 
 	msgCommon := ". Set SKIP_VPC to yes to skip VPC tests"
-	preAccountCheck(t, msgCommon)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preAccountCheck(t, msgCommon)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_vpn_profile_test.go
+++ b/aviatrix/resource_aviatrix_vpn_profile_test.go
@@ -23,10 +23,11 @@ func TestAccAviatrixVPNProfile_basic(t *testing.T) {
 	}
 	msg := ". Set SKIP_VPN_PROFILE to yes to skip VPN Profile tests"
 
-	preGatewayCheck(t, msg)
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preGatewayCheck(t, msg)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVPNProfileDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_vpn_user_accelerator_test.go
+++ b/aviatrix/resource_aviatrix_vpn_user_accelerator_test.go
@@ -21,10 +21,11 @@ func TestAccAviatrixVPNUserAccelerator_basic(t *testing.T) {
 	}
 	msgCommon := ". Set SKIP_VPN_USER_ACCELERATOR to skip VPN User Accelerator tests"
 
-	preGatewayCheck(t, msgCommon)
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preGatewayCheck(t, msgCommon)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVPNUserAcceleratorDestroy,
 		Steps: []resource.TestStep{

--- a/aviatrix/resource_aviatrix_vpn_user_test.go
+++ b/aviatrix/resource_aviatrix_vpn_user_test.go
@@ -23,10 +23,11 @@ func TestAccAviatrixVPNUser_basic(t *testing.T) {
 	}
 	msg := ". Set SKIP_VPN_USER to yes to skip VPN User tests"
 
-	preGatewayCheck(t, msg)
-
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck: func() {
+			testAccPreCheck(t)
+			preGatewayCheck(t, msg)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVPNUserDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
Hey Team,

This should be the final PR and we can release. 

The reason for this code chance is becuase we run `make test` in the release process which was failing due to env variable checks. I've moved these checks to be inside the TestAcc check call so they are not called during the simple unit test. 